### PR TITLE
Allow environment-side build mode setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BINDIR=$(DESTDIR)$(bindir)
 INCDIR=$(DESTDIR)$(incdir)/rav1e
 LIBDIR=$(DESTDIR)$(libdir)
 
-build_mode=debug
+build_mode?=debug
 
 all: target/$(build_mode)/librav1e.a rav1e.pc include/rav1e.h
 


### PR DESCRIPTION
It doesn't seem like build type can be changed without modifying `Makefile` currently, so this way one can call `build_mode release make` in order to build in release mode.