### PR TITLE
Remove non-existing test_script from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,6 @@ install:
 build_script:
     - cargo build --release --target=%target%
 
-test_script:
-   - cargo test --target=%target% --verbose
-
 artifacts:
     - path: target\$(target)\release\rav1e.lib
       name: librav1e-$(platform)


### PR DESCRIPTION
There is no test, so AppVeyor tries for 1 hour and then gives up. This patch removes the test script.