### PR TITLE
Test if Rust Nightly is producing builds again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ matrix:
 jobs:
   include:
       - name: "Linux build"
-        rust: nightly-2018-12-15
+        rust: beta
         script: make examples && ./simple_encoding
       - name: "macOS build"
         os: osx
-        rust: nightly-2018-12-15
+        rust: beta
         script: make examples && ./simple_encoding
       - name: "Linux build (Rust nightly)"
         rust: nightly


### PR DESCRIPTION
Rust Nightly is working again :).

I would propose to switch regular builds to beta channel (will add deploy to GitHub somewhere next week), and keep one nightly job going for testing.

Is it an idea to sync up crav1e (pre-)releases with rav1e? (so each week on tuesday).