### PR TITLE
Add some options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,9 @@ unsafe fn option_match(
 
         "threads" => (*cfg).cfg.threads = value.parse().map_err(|_| ())?,
 
+        "tile_rows_log2" => enc.tile_rows_log2 = value.parse().map_err(|_| ())?,
+        "tile_cols_log2" => enc.tile_cols_log2 = value.parse().map_err(|_| ())?,
+
         "tune" => enc.tune = value.parse().map_err(|_| ())?,
         "quantizer" => enc.quantizer = value.parse().map_err(|_| ())?,
         "bitrate" => enc.bitrate = value.parse().map_err(|_| ())?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,7 @@ unsafe fn option_match(
 
         "tune" => enc.tune = value.parse().map_err(|_| ())?,
         "quantizer" => enc.quantizer = value.parse().map_err(|_| ())?,
+        "bitrate" => enc.bitrate = value.parse().map_err(|_| ())?,
 
         "key_frame_interval" => enc.max_key_frame_interval = value.parse().map_err(|_| ())?,
         "min_key_frame_interval" => enc.min_key_frame_interval = value.parse().map_err(|_| ())?,


### PR DESCRIPTION
When bitrated is used, it is currently pinned to one pass only, since, as far as I know, this all rav1e currently supports.
